### PR TITLE
species key is now used when searching for target species

### DIFF
--- a/pyteck/simulation.py
+++ b/pyteck/simulation.py
@@ -410,10 +410,13 @@ class Simulation(object):
             ind = None
             for sp in try_list:
                 try:
-                    ind = self.gas.species_index(sp)
+                    ind = self.gas.species_index(species_key[sp])
                     break
                 except ValueError:
                     pass
+                except KeyError:
+                    pass
+
 
             # store index of target species
             if ind:


### PR DESCRIPTION
When searching for the target species, the species key is now used to translate between the target species requested by the experimental data set and the species name used in the model.